### PR TITLE
Deploy Unikraft Cloud with erofs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ Cargo.lock
 base/
 
 rootfs*
+.rootfs
+initrd

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use Debian Bookworm as the base image for both build and runtime
-FROM debian:bookworm-slim as sys
+FROM debian:bookworm-slim AS sys
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,9 @@ COPY ./src ./src
 # Build the Rust project
 RUN cargo build --release
 
+# Create blank directory to be used as the source of other empty directories.
+RUN mkdir /blank
+
 FROM scratch
 
 # Node binary
@@ -99,5 +102,8 @@ COPY --from=sys /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
 # Dynamic linker / loader
 COPY --from=sys /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
 
-# Copy wrappers script
+# Create temporary directory.
+COPY --from=sys /blank /tmp
+
+# Copy wrapper script.
 COPY ./wrapper.sh /usr/bin/wrapper.sh

--- a/Kraftfile.erofs
+++ b/Kraftfile.erofs
@@ -1,0 +1,14 @@
+spec: v0.6
+
+name: code-runner
+
+runtime: base-compat:latest
+
+labels:
+  cloud.unikraft.v1.instances/scale_to_zero.policy: "on"
+  cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
+  cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
+
+rootfs: ./initrd
+
+cmd: ["/usr/bin/wrapper.sh"]

--- a/README.ukc.md
+++ b/README.ukc.md
@@ -1,0 +1,25 @@
+# Code Runner on Unikraft Cloud
+
+To deploy Code Runner on Unikraft Cloud, follow the steps below.
+
+1. Make sure you have `erofs` installed.
+   On a Debian-based distribution, use:
+
+   ```console
+   sudo apt update
+   sudo apt install -y erofs-utils
+   ```
+
+1. Have [Docker](/home/razvan/orgs/unikraft-io/pocs/tinyfish/chromium-cdp) and [KraftKit](https://unikraft.org/docs/cli/install) installed.
+
+1. Create root filesystem as an initrd file and use `erofs` (Extended Read-only Filesystem):
+
+   ```console
+   ./create-initrd.sh
+   ```
+
+1. Deploy Code Runner on Unikraft Cloud:
+
+   ```console
+   kraft cloud deploy --kraftfile Kraftfile.erofs --port 443:4000 --memory 1Gi --name code-runner --subdomain code-runner .
+   ```

--- a/create-initrd.sh
+++ b/create-initrd.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Clean up previous files.
+rm -fr .rootfs
+rm -f initrd
+
+docker build -t ml-code-runner .
+docker create --name cnt-ml-code-runner ml-code-runner /bin/sh
+docker cp cnt-ml-code-runner:/ .rootfs
+docker rm cnt-ml-code-runner
+
+mkfs.erofs --all-root -d2 -E noinline_data initrd ./.rootfs


### PR DESCRIPTION
EROFS (enhanced read-only filesystem) is used by Unikraft Cloud to create memory-efficient builds. With EROFS, an initial ramdisk image is used: it is mounted in an on-demand manner by Unikraft Cloud instances. Moreover, multiple instances will share the same erofs image.
    
Add:
- `create-initrd.sh`: script to create the initrd used by EROFS (from the Dockerfile)
- `Kraftfile.erofs`: Kraftfile to deploy with EROFS
- `README.ukc.md`: README file to document the use and EROFS and the deployment on Unikraft Cloud
 
Also ignore artifacts of the `create-initrd.sh` script: the `.rootfs/` directory and the `initrd` file.